### PR TITLE
Fix Android 14/15 startup crash and unconditional self-monitor

### DIFF
--- a/app/src/main/cpp/AudioEngine.cpp
+++ b/app/src/main/cpp/AudioEngine.cpp
@@ -241,9 +241,13 @@ oboe::DataCallbackResult AudioEngine::onAudioReady(
     // Always dispatch processed audio to Kotlin monitor (for SoftwareLoopback/metering)
     dispatchToKotlin(out, numFrames);
 
-
-
-
+    // The device output stream must stay silent. The audible "monitor" is produced by
+    // SoftwareLoopback's AudioTrack, which is user-toggleable and routed to the chosen
+    // output device. Leaving the processed mic in `out` here would play it to the
+    // speaker/earpiece unconditionally - i.e. you always hear yourself, even with the
+    // monitor switched off. dispatchToKotlin() already copied the buffer, so zeroing it
+    // now does not affect the virtual-mic / loopback path.
+    std::fill(out, out + numFrames, 0.0f);
 
     return oboe::DataCallbackResult::Continue;
 }

--- a/app/src/main/java/com/micplugin/MainActivity.kt
+++ b/app/src/main/java/com/micplugin/MainActivity.kt
@@ -2,9 +2,12 @@ package com.micplugin
 
 import android.Manifest
 import android.content.Intent
+import android.content.pm.PackageManager
 import android.net.Uri
 import android.os.Build
 import android.os.Environment
+import android.os.PowerManager
+import androidx.lifecycle.Lifecycle
 import android.provider.Settings
 import android.os.Bundle
 import androidx.activity.ComponentActivity
@@ -46,12 +49,17 @@ class MainActivity : ComponentActivity() {
         if (Build.VERSION.SDK_INT <= 32) add(Manifest.permission.READ_EXTERNAL_STORAGE)
     }.toTypedArray()
 
+    // Guards so the microphone foreground service is started exactly once, and only
+    // while the app is actually in the foreground (required on Android 14+).
+    private var audioServiceStarted = false
+
     private val permissionLauncher = registerForActivityResult(
         ActivityResultContracts.RequestMultiplePermissions()
-    ) { results ->
-        val allGranted = results.values.all { it }
-        if (allGranted) startAudioService()
-        requestBatteryOptimizationExemption()
+    ) { _ ->
+        // Don't start the service here: when this callback fires the app may still be
+        // behind a permission dialog / settings screen, i.e. in the background.
+        // onResume() starts it once we are back in the foreground and in an eligible state.
+        maybeStartAudioService()
     }
 
     // Shizuku permission result listener
@@ -150,13 +158,31 @@ class MainActivity : ComponentActivity() {
         super.onDestroy()
     }
 
-    private fun startAudioService() {
+    override fun onResume() {
+        super.onResume()
+        // Starting the microphone foreground service here guarantees the app is in the
+        // foreground (RESUMED), which Android 14+ requires for a "microphone" FGS.
+        maybeStartAudioService()
+    }
+
+    private fun maybeStartAudioService() {
+        if (audioServiceStarted) return
+        if (checkSelfPermission(Manifest.permission.RECORD_AUDIO)
+            != PackageManager.PERMISSION_GRANTED
+        ) return
+        if (!lifecycle.currentState.isAtLeast(Lifecycle.State.RESUMED)) return
+        audioServiceStarted = true
         AudioProcessingService.start(this)
+        // Prompt for battery-optimization exemption only once, after the service is up.
         requestBatteryOptimizationExemption()
     }
 
     private fun requestBatteryOptimizationExemption() {
         if (Build.VERSION.SDK_INT >= 23) {
+            // Don't bother the user if the app is already exempt — otherwise the battery
+            // settings screen pops up on every launch / every time the app is reopened.
+            val pm = getSystemService(PowerManager::class.java)
+            if (pm != null && pm.isIgnoringBatteryOptimizations(packageName)) return
             val intent = Intent(Settings.ACTION_REQUEST_IGNORE_BATTERY_OPTIMIZATIONS).apply {
                 data = Uri.parse("package:$packageName")
             }

--- a/app/src/main/java/com/micplugin/service/AudioProcessingService.kt
+++ b/app/src/main/java/com/micplugin/service/AudioProcessingService.kt
@@ -113,11 +113,21 @@ class AudioProcessingService : Service() {
     override fun onCreate() {
         super.onCreate()
         createNotificationChannel()
-        if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.Q) {
-            startForeground(NOTIF_ID, buildNotification("Starting…", 0, 0f),
-                android.content.pm.ServiceInfo.FOREGROUND_SERVICE_TYPE_MICROPHONE)
-        } else {
-            startForeground(NOTIF_ID, buildNotification("Starting…", 0, 0f))
+        try {
+            if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.Q) {
+                startForeground(NOTIF_ID, buildNotification("Starting…", 0, 0f),
+                    android.content.pm.ServiceInfo.FOREGROUND_SERVICE_TYPE_MICROPHONE)
+            } else {
+                startForeground(NOTIF_ID, buildNotification("Starting…", 0, 0f))
+            }
+        } catch (e: Exception) {
+            // Android 14+ throws SecurityException / ForegroundServiceStartNotAllowedException
+            // when a microphone foreground service is started while the app is not in an
+            // eligible (foreground) state. Fail gracefully instead of crashing the whole app;
+            // MainActivity will (re)start the service from onResume() while in the foreground.
+            android.util.Log.e("MicUp.Service", "startForeground(microphone) not allowed: $e")
+            stopSelf()
+            return
         }
         acquireWakeLock()
     }

--- a/app/src/main/java/com/micplugin/service/SoftwareLoopback.kt
+++ b/app/src/main/java/com/micplugin/service/SoftwareLoopback.kt
@@ -37,6 +37,10 @@ object SoftwareLoopback {
         if (running) return
         audioManager = context.getSystemService(AudioManager::class.java)
 
+        // Respect the persisted monitor on/off choice on (re)start, even before the UI loads.
+        monitorEnabled = context.getSharedPreferences("micup_prefs", Context.MODE_PRIVATE)
+            .getBoolean("monitor_enabled", true)
+
         val minBuf = AudioTrack.getMinBufferSize(SAMPLE_RATE,
             AudioFormat.CHANNEL_OUT_MONO, FORMAT).coerceAtLeast(4096)
 

--- a/app/src/main/java/com/micplugin/ui/AudioViewModel.kt
+++ b/app/src/main/java/com/micplugin/ui/AudioViewModel.kt
@@ -301,9 +301,19 @@ class AudioViewModel @Inject constructor(
     private val _monitoringEnabled = MutableStateFlow(true)
     val monitoringEnabled: kotlinx.coroutines.flow.StateFlow<Boolean> = _monitoringEnabled
 
-    fun setMonitoring(enabled: Boolean) {
+    fun setMonitoring(context: android.content.Context, enabled: Boolean) {
         _monitoringEnabled.value = enabled
         SoftwareLoopback.setMonitorEnabled(enabled)
+        // Remember the choice so it survives app/process restarts.
+        context.getSharedPreferences("micup_prefs", android.content.Context.MODE_PRIVATE)
+            .edit().putBoolean("monitor_enabled", enabled).apply()
+    }
+
+    fun loadMonitoring(context: android.content.Context) {
+        val saved = context.getSharedPreferences("micup_prefs", android.content.Context.MODE_PRIVATE)
+            .getBoolean("monitor_enabled", true)
+        _monitoringEnabled.value = saved
+        SoftwareLoopback.setMonitorEnabled(saved)
     }
 
 

--- a/app/src/main/java/com/micplugin/ui/MainScreen.kt
+++ b/app/src/main/java/com/micplugin/ui/MainScreen.kt
@@ -41,6 +41,9 @@ fun MainScreen(navController: NavController, vm: AudioViewModel = hiltViewModel(
     var showSaveDialog by remember { mutableStateOf(false) }
     var presetName     by remember { mutableStateOf("") }
 
+    // Restore the saved monitor on/off choice so it isn't reset to "on" on every launch.
+    LaunchedEffect(Unit) { vm.loadMonitoring(context) }
+
     Column(
         modifier = Modifier
             .fillMaxSize()
@@ -188,7 +191,7 @@ fun MainScreen(navController: NavController, vm: AudioViewModel = hiltViewModel(
                 }
                 Switch(
                     checked = monitoring,
-                    onCheckedChange = { vm.setMonitoring(it) },
+                    onCheckedChange = { vm.setMonitoring(context, it) },
                     colors = SwitchDefaults.colors(
                         checkedThumbColor   = Color.White,
                         checkedTrackColor   = StudioColors.Accent,


### PR DESCRIPTION
Fixes four issues seen on a stock Android 15 device: #9  

1. **Startup crash**: the `microphone foreground service` was started from the
   permission callback while the app was behind the settings screens (background),
   which Android 15+ disallows. Now it starts from `onResume()` (foreground) and
   `startForeground()` is guarded against failure. Also removes a duplicate
   battery-optimization prompt.
2. **You always hear yourself**: the native Oboe callback left the processed mic in
   the output buffer, so it was played to the device output unconditionally (param 98
   "monitoring" is a no-op no `case 98` in the native `setParam`). The output buffer
   is now zeroed after dispatching to the loopback, so SoftwareLoopback's `AudioTrack`
   is the only audible monitor and the UI toggle works.
3. **Monitor resets to on**: the monitor on/off choice is now persisted
4. **battery prompt every launch**: the battery-optimization screen only opens when the app isn't already unresricted

## Testing

Tested only on my own physical device (Xiaomi 23108RN04Y, Android 15). No crash on
launch. Monitor toggle works and the off state survives restarts. Battery prompt no
longer reappears once granted. I haven't tested on other devices or an emulator.